### PR TITLE
README.md: add link to "Library Classes & Workshops" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/NYULibraries/libcal-assets.svg?style=svg)](https://circleci.com/gh/NYULibraries/libcal-assets)
 
-Manage the CSS and JS for NYU Libraries' instance of SpringShare's LibCal product.
+Manage the CSS and JS for NYU Libraries' instance of SpringShare's LibCal product:
+[Library Classes & Workshops](https://nyu.libcal.com/)
 
 ## CSS
 


### PR DESCRIPTION
The impetus for this branch was to test that deployment works for new access key, but it's useful to have the link in the README.md anyway.