### PR TITLE
chore: fix Sass deprecation warnings

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 #s-lc-public-bc .breadcrumb {
     font-size: $font_size_base;
     font-weight: $weight_normal;

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 button,
 .btn,
 .btn-primary,

--- a/scss/_focus_a11y.scss
+++ b/scss/_focus_a11y.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as *;
+
 a, 
 button,
 textarea,

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -1,3 +1,7 @@
+@use 'colors' as *;
+@use 'variables' as *;
+@use 'mixins' as *;
+
 #s-lc-public-footer {
   background-color: $text_black;
   border-top: none;

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 header.header {
   background-color: $nyu_purple;
   div.logo {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 @mixin focusOutline{
   -webkit-box-shadow: inset 0 0 0 2px $border_focus;
   box-shadow: inset 0 0 0 2px $border_focus !important;

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,13 +1,13 @@
-@import 'legacy';
-@import 'variables';
-@import 'colors';
-@import 'mixins';
-@import 'focus_a11y';
-@import 'header';
-@import 'footer';
-@import 'skip_link';
-@import 'breadcrumb';
-@import 'buttons';
+@use 'variables' as *;
+@use 'colors' as *;
+@use 'mixins' as *;
+@use 'legacy';
+@use 'focus_a11y';
+@use 'header';
+@use 'footer';
+@use 'skip_link';
+@use 'breadcrumb';
+@use 'buttons';
 
 body {
   padding-left: 0;


### PR DESCRIPTION
## Summary
- Replace deprecated Sass @import usage with @use in the SCSS entrypoint.
- Add explicit Sass module dependencies for partials that use shared variables and mixins.
